### PR TITLE
Fixed the garbled content on iOS

### DIFF
--- a/sass/layout/_content-about.scss
+++ b/sass/layout/_content-about.scss
@@ -19,6 +19,9 @@ section.about.promo {
 	align-items: flex-start;
 
 	.promobox {
+
+		max-width: 100%;
+
 		@include flexboxRow1;
 		align-items: flex-start;
 		margin-bottom: 4%;
@@ -37,6 +40,10 @@ section.about.promo {
 	.promobox .imgFrame {
 		//flex child
 		flex: 1 25%;
+
+		img {
+			max-width: 100%;
+		}
 
 		@include phoneR {
 			//flex child

--- a/sass/layout/_content-about.scss
+++ b/sass/layout/_content-about.scss
@@ -20,7 +20,7 @@ section.about.promo {
 
 	.promobox {
 
-		max-width: 100%;
+		// max-width: 100%;
 
 		@include flexboxRow1;
 		align-items: flex-start;
@@ -28,11 +28,13 @@ section.about.promo {
 
 		@include phoneR {
 			flex: 1 100%;
+			flex: 1 auto;
 			margin-bottom: 10%;
 		}
 
 		@include iphone6Plus414R {
 			flex: 1 100%;
+			flex: 1 auto;
 			margin-bottom: 10%;
 		}
 	}

--- a/sass/layout/_content-suites.scss
+++ b/sass/layout/_content-suites.scss
@@ -15,18 +15,20 @@ section.suites.promo {
 
 	.promobox {
 
-		max-width: 100%;
+		// max-width: 100%;
 
 		// flex child
 		flex: 1 28%;
 
 		@include phoneR {
 			flex: 1 100%;
+			flex: 1 auto;
 			margin-bottom: 5%;
 		}
 	
 		@include iphone6Plus414R {
 			flex: 1 100%;
+			flex: 1 auto;
 			margin-bottom: 5%;
 		}
 	}

--- a/sass/layout/_content-suites.scss
+++ b/sass/layout/_content-suites.scss
@@ -14,6 +14,9 @@ section.suites.promo {
 	// padding-top: 5%;
 
 	.promobox {
+
+		max-width: 100%;
+
 		// flex child
 		flex: 1 28%;
 
@@ -39,6 +42,10 @@ section.suites.promo {
 		@include flexboxColumn1;
 
 		@include transitionEffectAllEaseIn(1s);
+
+		img {
+			max-width: 100%;
+		}
 	}
 
 	.promobox .imgFrame:hover > .playFrame {

--- a/sass/layout/_footer.scss
+++ b/sass/layout/_footer.scss
@@ -40,8 +40,16 @@ footer.site-footer .site-info {
 	aside.copyright,aside.socialIcons,nav {
 		// flex child
 		flex: 1 33%;
+
 		@include phoneR {
-		  width: 100%;
+		  	width: 100%;
+
+			// on iOS Safari
+			// especially iPhone 4S...  these 3 elements are squished together like a sandwich
+			// @include sectionMargins041515(5%,5%);
+			
+			flex: 1 auto;
+
 		}
 	}
 

--- a/sass/layout/_layout.scss
+++ b/sass/layout/_layout.scss
@@ -25,6 +25,7 @@ this contains both the content and the sidebar
 		// using standard width is apparently enough
 		// flex: 2 75%;
 		// finding that using flex: 1 auto is better in many cases as flexbox figures out how to position it automatically
+		// this is because the initial width of 75% has already been set, so flexbox just works with that
 		flex: 1 auto;
 
 		padding-right: 5%;
@@ -52,6 +53,7 @@ this contains both the content and the sidebar
 		// on Safari desktop and iOS adding this flex here seems to break it
 		// using standard width is apparently enough
 		// flex: 1 25%;
+		// this is because the initial width of 25% has already been set, so flexbox just works with that
 		flex: 1 auto;
 
 		// push the section down from the top

--- a/sass/layout/_layout.scss
+++ b/sass/layout/_layout.scss
@@ -21,7 +21,9 @@ this contains both the content and the sidebar
 		width: 75%;
 		/*================================================ */
 		
-		flex: 2 75%;
+		// on Safari desktop and iOS adding this flex here seems to break it
+		// using standard width is apparently enough
+		// flex: 2 75%;
 
 		padding-right: 5%;
 
@@ -29,6 +31,10 @@ this contains both the content and the sidebar
 		margin-top: 5%;
 
 		@include desktopR {
+			width: 100%;
+		}
+
+		@include iphone6Minus568R {
 			width: 100%;
 		}
 	}
@@ -41,13 +47,23 @@ this contains both the content and the sidebar
 		width: 25%;
 		/*================================================ */
 		
-		flex: 1 25%;
+		// on Safari desktop and iOS adding this flex here seems to break it
+		// using standard width is apparently enough
+		// flex: 1 25%;
 
 		// push the section down from the top
 		margin-top: 5%;
 
 		@include desktopR {
 			width: 100%;
+		}
+
+		@include iphone6Minus568R {
+			width: 100%;
+		}
+
+		@include phoneR {
+			width:100%;
 		}
 	}
 }

--- a/sass/layout/_layout.scss
+++ b/sass/layout/_layout.scss
@@ -24,6 +24,8 @@ this contains both the content and the sidebar
 		// on Safari desktop and iOS adding this flex here seems to break it
 		// using standard width is apparently enough
 		// flex: 2 75%;
+		// finding that using flex: 1 auto is better in many cases as flexbox figures out how to position it automatically
+		flex: 1 auto;
 
 		padding-right: 5%;
 
@@ -50,6 +52,7 @@ this contains both the content and the sidebar
 		// on Safari desktop and iOS adding this flex here seems to break it
 		// using standard width is apparently enough
 		// flex: 1 25%;
+		flex: 1 auto;
 
 		// push the section down from the top
 		margin-top: 5%;

--- a/style.css
+++ b/style.css
@@ -278,12 +278,12 @@ this contains both the content and the sidebar
     float: left;
     width: 75%;
     /*================================================ */
-    -webkit-flex: 2 75%;
-    -ms-flex: 2 75%;
-    flex: 2 75%;
     padding-right: 5%;
     margin-top: 5%; }
     @media (max-width: 940px) {
+      .flexbox #primary {
+        width: 100%; } }
+    @media (max-width: 568px) {
       .flexbox #primary {
         width: 100%; } }
   .flexbox #secondary {
@@ -293,11 +293,14 @@ this contains both the content and the sidebar
     float: right;
     width: 25%;
     /*================================================ */
-    -webkit-flex: 1 25%;
-    -ms-flex: 1 25%;
-    flex: 1 25%;
     margin-top: 5%; }
     @media (max-width: 940px) {
+      .flexbox #secondary {
+        width: 100%; } }
+    @media (max-width: 568px) {
+      .flexbox #secondary {
+        width: 100%; } }
+    @media (max-width: 480px) {
       .flexbox #secondary {
         width: 100%; } }
 
@@ -1549,6 +1552,7 @@ section.about.promo {
     display: block;
     margin-bottom: 5%; }
   section.about.promo .promobox {
+    max-width: 100%;
     display: -webkit-flex;
     display: -ms-flexbox;
     display: flex;
@@ -1584,6 +1588,8 @@ section.about.promo {
     -webkit-flex: 1 25%;
     -ms-flex: 1 25%;
     flex: 1 25%; }
+    section.about.promo .promobox .imgFrame img {
+      max-width: 100%; }
     @media (max-width: 480px) {
       section.about.promo .promobox .imgFrame {
         -webkit-flex: 1 100%;
@@ -1614,6 +1620,7 @@ overall layout is found in layout/_layout.scss
 SUITES PROMO
 =================================================*/
 section.suites.promo .promobox {
+  max-width: 100%;
   -webkit-flex: 1 28%;
   -ms-flex: 1 28%;
   flex: 1 28%; }
@@ -1656,6 +1663,8 @@ section.suites.promo .promobox .imgFrame {
   -moz-transition: all 1s ease-in;
   -o-transition: all 1s ease-in;
   -ms-transition: all 1s ease-in; }
+  section.suites.promo .promobox .imgFrame img {
+    max-width: 100%; }
 
 section.suites.promo .promobox .imgFrame:hover > .playFrame {
   display: -webkit-flex;

--- a/style.css
+++ b/style.css
@@ -278,6 +278,9 @@ this contains both the content and the sidebar
     float: left;
     width: 75%;
     /*================================================ */
+    -webkit-flex: 1 auto;
+    -ms-flex: 1 auto;
+    flex: 1 auto;
     padding-right: 5%;
     margin-top: 5%; }
     @media (max-width: 940px) {
@@ -293,6 +296,9 @@ this contains both the content and the sidebar
     float: right;
     width: 25%;
     /*================================================ */
+    -webkit-flex: 1 auto;
+    -ms-flex: 1 auto;
+    flex: 1 auto;
     margin-top: 5%; }
     @media (max-width: 940px) {
       .flexbox #secondary {
@@ -1552,7 +1558,6 @@ section.about.promo {
     display: block;
     margin-bottom: 5%; }
   section.about.promo .promobox {
-    max-width: 100%;
     display: -webkit-flex;
     display: -ms-flexbox;
     display: flex;
@@ -1577,12 +1582,18 @@ section.about.promo {
         -webkit-flex: 1 100%;
         -ms-flex: 1 100%;
         flex: 1 100%;
+        -webkit-flex: 1 auto;
+        -ms-flex: 1 auto;
+        flex: 1 auto;
         margin-bottom: 10%; } }
     @media (max-width: 414px) {
       section.about.promo .promobox {
         -webkit-flex: 1 100%;
         -ms-flex: 1 100%;
         flex: 1 100%;
+        -webkit-flex: 1 auto;
+        -ms-flex: 1 auto;
+        flex: 1 auto;
         margin-bottom: 10%; } }
   section.about.promo .promobox .imgFrame {
     -webkit-flex: 1 25%;
@@ -1620,7 +1631,6 @@ overall layout is found in layout/_layout.scss
 SUITES PROMO
 =================================================*/
 section.suites.promo .promobox {
-  max-width: 100%;
   -webkit-flex: 1 28%;
   -ms-flex: 1 28%;
   flex: 1 28%; }
@@ -1629,12 +1639,18 @@ section.suites.promo .promobox {
       -webkit-flex: 1 100%;
       -ms-flex: 1 100%;
       flex: 1 100%;
+      -webkit-flex: 1 auto;
+      -ms-flex: 1 auto;
+      flex: 1 auto;
       margin-bottom: 5%; } }
   @media (max-width: 414px) {
     section.suites.promo .promobox {
       -webkit-flex: 1 100%;
       -ms-flex: 1 100%;
       flex: 1 100%;
+      -webkit-flex: 1 auto;
+      -ms-flex: 1 auto;
+      flex: 1 auto;
       margin-bottom: 5%; } }
 
 section.suites.promo .promobox h2 {
@@ -2752,7 +2768,10 @@ footer.site-footer .site-info {
     flex: 1 33%; }
     @media (max-width: 480px) {
       footer.site-footer .site-info aside.copyright, footer.site-footer .site-info aside.socialIcons, footer.site-footer .site-info nav {
-        width: 100%; } }
+        width: 100%;
+        -webkit-flex: 1 auto;
+        -ms-flex: 1 auto;
+        flex: 1 auto; } }
   footer.site-footer .site-info aside.socialIcons {
     display: -webkit-flex;
     display: -ms-flexbox;


### PR DESCRIPTION
The issue was using flex: 1 100% to set the positioning... instead using flex: 1 auto and allowing flexbox to automatically adjust things worked.  The flex: 1 100% constrained it. 

It's working on my iPhone 4S for the interior pages with sidebars.

Noticing that the page often has to be loaded twice or thrice for animations to work sometimes.  Could be the load or my Net is slow as it usually is.
